### PR TITLE
Revert "[Fix] add a missing semicolon in the LogAktivitas Model"

### DIFF
--- a/app/Models/LogAktivitas.php
+++ b/app/Models/LogAktivitas.php
@@ -11,7 +11,7 @@ class LogAktivitas extends Model
 
     protected $table = 'log_aktivitas';
 
-    protected $primaryKey = 'id_log_aktivitas';
+    protected $primaryKey = 'id_log_aktivitas'
 
     protected $fillable = [
         'id_kota',


### PR DESCRIPTION
This PR fixes all seeder issues and disables timestamps in the model config.
For people from the integrator team, please test all of your code before pushing to the dev branch.

This PR is just a workaround, by the way. Please update the data properly.

Anyway, it seems like the integrator team is using AI for their code, so here’s an AI-generated comment:
```
This pull request includes a minor change to the `app/Models/LogAktivitas.php` file. The change corrects the syntax for the `primaryKey` property by adding a missing semicolon at the end of the line.

* [`app/Models/LogAktivitas.php`](diffhunk://#diff-be1879602fe5f33344b11e62acabd162e2c471574c8cd929aebcbd6356d9fcacL14-R14): Added a missing semicolon to the `primaryKey` property declaration.
```