### PR TITLE
[Fix] Typo on Seeder

### DIFF
--- a/database/seeders/ProdiSeeder.php
+++ b/database/seeders/ProdiSeeder.php
@@ -25,7 +25,7 @@ class ProdiSeeder extends Seeder
         ]);
 
         Prodi::create([
-            'nama_prodi' => 'D4-Tekinik Informatika',
+            'nama_prodi' => 'D4-Teknik Informatika',
             'maksimal_anggota_kota' => 2,
             'maksimal_mahasiswa_bimbingan' => 8
         ]);


### PR DESCRIPTION
This pull request includes a minor correction in the `ProdiSeeder` class. The change fixes a typo in the `nama_prodi` field for a `Prodi` record.

* **Typo correction**:
  * [`database/seeders/ProdiSeeder.php`](diffhunk://#diff-ebe53c762c34f32f11913e6f1e9c509d3da64a9aaf49a84025675c46dd09e08dL28-R28): Corrected the spelling of `'D4-Tekinik Informatika'` to `'D4-Teknik Informatika'` in the `Prodi::create` method.